### PR TITLE
[BE] feat - #111 : 실시간 채팅 기능 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	// MySQL
 	implementation "mysql:mysql-connector-java:8.0.32"
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/jeju/oneroom/auth/service/JwtTokenizer.java
+++ b/server/src/main/java/jeju/oneroom/auth/service/JwtTokenizer.java
@@ -1,7 +1,5 @@
 package jeju.oneroom.auth.service;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.security.Keys;
@@ -68,6 +66,17 @@ public class JwtTokenizer {
                 .build()
                 .parseClaimsJws(jws);
         return claims;
+    }
+
+    public void verifyAccessToken(
+            String accessToken
+    ) {
+        String base64SecretKey = encodeBase64SecretKey(getSecretKey());
+        try {
+            verifySignature(accessToken, base64SecretKey);
+        } catch (ExpiredJwtException e) {
+            throw new RuntimeException("EXPIRED_ACCESS_TOKEN");
+        }
     }
 
     public void verifySignature(String jws, String base64EncodedSecretKey) {

--- a/server/src/main/java/jeju/oneroom/message/config/RedisConfig.java
+++ b/server/src/main/java/jeju/oneroom/message/config/RedisConfig.java
@@ -1,0 +1,62 @@
+package jeju.oneroom.message.config;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration();
+        clusterConfiguration.clusterNode(host, port);
+
+        LettuceClientConfiguration clientConfiguration = LettuceClientConfiguration.builder()
+                .clientOptions(ClientOptions.builder()
+                        .socketOptions(SocketOptions.builder()
+                                .connectTimeout(Duration.ofMillis(60))
+                                .build())
+                        .build())
+                .commandTimeout(Duration.ofSeconds(60))
+                .build();
+
+        return new LettuceConnectionFactory(clusterConfiguration, clientConfiguration);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        return container;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+
+        return redisTemplate;
+    }
+}

--- a/server/src/main/java/jeju/oneroom/message/config/RedisConfig.java
+++ b/server/src/main/java/jeju/oneroom/message/config/RedisConfig.java
@@ -5,8 +5,8 @@ import io.lettuce.core.SocketOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -27,9 +27,7 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration();
-        clusterConfiguration.clusterNode(host, port);
-
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
         LettuceClientConfiguration clientConfiguration = LettuceClientConfiguration.builder()
                 .clientOptions(ClientOptions.builder()
                         .socketOptions(SocketOptions.builder()
@@ -39,7 +37,7 @@ public class RedisConfig {
                 .commandTimeout(Duration.ofSeconds(60))
                 .build();
 
-        return new LettuceConnectionFactory(clusterConfiguration, clientConfiguration);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfiguration);
     }
 
     @Bean

--- a/server/src/main/java/jeju/oneroom/message/config/WebSocketConfig.java
+++ b/server/src/main/java/jeju/oneroom/message/config/WebSocketConfig.java
@@ -1,0 +1,39 @@
+package jeju.oneroom.message.config;
+
+import jeju.oneroom.message.config.handler.WebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.*;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // 해당 경로를 구독한 사람에게 메시지 전달
+        config.enableSimpleBroker("/sub");
+
+        // 클라이언트에서 서버로 메세지를 보낼 때 붙이는 prefix
+        config.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chat")
+                .setAllowedOrigins("http://localhost:3000")     // TODO 추후 접근 경로 수정 필요
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketHandler);
+    }
+}

--- a/server/src/main/java/jeju/oneroom/message/config/WebSocketConfig.java
+++ b/server/src/main/java/jeju/oneroom/message/config/WebSocketConfig.java
@@ -28,8 +28,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/chat")
-                .setAllowedOrigins("http://localhost:3000")     // TODO 추후 접근 경로 수정 필요
-                .withSockJS();
+                .setAllowedOriginPatterns("*");
     }
 
     @Override

--- a/server/src/main/java/jeju/oneroom/message/config/handler/WebSocketHandler.java
+++ b/server/src/main/java/jeju/oneroom/message/config/handler/WebSocketHandler.java
@@ -1,0 +1,39 @@
+package jeju.oneroom.message.config.handler;
+
+import jeju.oneroom.auth.service.JwtTokenizer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketHandler implements ChannelInterceptor {
+
+    private final JwtTokenizer jwtTokenizer;
+
+    // websocket 요청 시, 필터 역할
+    @Override
+    @CrossOrigin
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if (StompCommand.CONNECT == accessor.getCommand()) {
+            String jwt = Optional.ofNullable(accessor.getFirstNativeHeader("Authorization"))
+                    .orElseThrow(() -> new RuntimeException("ACCESS_DENIED"))
+                    .substring("Bearer ".length());
+
+            jwtTokenizer.verifyAccessToken(jwt);
+        }
+
+        return message;
+    }
+}

--- a/server/src/main/java/jeju/oneroom/message/controller/MessageController.java
+++ b/server/src/main/java/jeju/oneroom/message/controller/MessageController.java
@@ -1,0 +1,51 @@
+package jeju.oneroom.message.controller;
+
+import jeju.oneroom.message.dto.MessageDto;
+import jeju.oneroom.message.service.MessageService;
+import jeju.oneroom.messageroom.entity.MessageRoom;
+import jeju.oneroom.messageroom.service.MessageRoomService;
+import jeju.oneroom.user.entity.User;
+import jeju.oneroom.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@Slf4j
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/messages")
+public class MessageController {
+
+    private final UserService userService;
+    private final MessageService messageService;
+    private final MessageRoomService messageRoomService;
+
+    @PostMapping
+    public ResponseEntity<MessageDto.Response> postMessage(@Valid @RequestBody MessageDto.Post postDto) {
+        MessageRoom messageRoom = messageRoomService.findVerifiedMessageRoom(postDto.getMessageRoomId());
+        User sender = userService.verifyExistsUser(postDto.getSenderId());  // email
+        User receiver = userService.verifyExistsUser(postDto.getReceiverId());
+
+        MessageDto.Response response = messageService.createMessage(postDto, messageRoom, sender, receiver);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @MessageMapping("/chats/{roomId}")
+    public void handleChatMessage(@DestinationVariable Long roomId,
+                                  @Valid @RequestBody MessageDto.Post postDto) {
+        MessageRoom messageRoom = messageRoomService.findVerifiedMessageRoom(postDto.getMessageRoomId());
+        User sender = userService.verifyExistsUser(postDto.getSenderId());  // email
+        User receiver = userService.verifyExistsUser(postDto.getReceiverId());
+
+        messageService.createMessage(postDto, messageRoom, sender, receiver);
+    }
+}

--- a/server/src/main/java/jeju/oneroom/message/dto/MessageDto.java
+++ b/server/src/main/java/jeju/oneroom/message/dto/MessageDto.java
@@ -1,0 +1,51 @@
+package jeju.oneroom.message.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public class MessageDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Post {
+
+        @NotNull
+        private Long messageRoomId;
+
+        @NotNull
+        private Long senderId;  // email
+
+        @NotNull
+        private Long receiverId;
+
+        @NotNull
+        private String content;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+
+        private Long messageId;
+        private String content;
+        private Long messageRoomId;
+        private Long senderId;
+        private String senderName;
+        private Long receiverId;
+        private String receiverName;
+
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        private LocalDateTime createdAt;
+    }
+}

--- a/server/src/main/java/jeju/oneroom/message/entity/Message.java
+++ b/server/src/main/java/jeju/oneroom/message/entity/Message.java
@@ -1,0 +1,48 @@
+package jeju.oneroom.message.entity;
+
+import jeju.oneroom.common.entity.BaseEntity;
+import jeju.oneroom.messageroom.entity.MessageRoom;
+import jeju.oneroom.user.entity.User;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long messageId;
+
+    @Setter
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Setter
+    @ManyToOne(cascade = CascadeType.DETACH, fetch = FetchType.LAZY)
+    private MessageRoom messageRoom;
+
+    @Setter
+    @ManyToOne(cascade = CascadeType.DETACH, fetch = FetchType.LAZY)
+    private User sender;
+
+    @Setter
+    @ManyToOne(cascade = CascadeType.DETACH, fetch = FetchType.LAZY)
+    private User receiver;
+
+    @Builder
+    public Message(MessageRoom messageRoom, User sender, User receiver, String content) {
+        this.messageRoom = messageRoom;
+        this.sender = sender;
+        this.receiver = receiver;
+        this.content = content;
+    }
+
+    public void setProperties(MessageRoom messageRoom, User sender, User receiver) {
+        this.messageRoom = messageRoom;
+        this.sender = sender;
+        this.receiver = receiver;
+    }
+}

--- a/server/src/main/java/jeju/oneroom/message/mapper/MessageMapper.java
+++ b/server/src/main/java/jeju/oneroom/message/mapper/MessageMapper.java
@@ -1,0 +1,18 @@
+package jeju.oneroom.message.mapper;
+
+import jeju.oneroom.message.dto.MessageDto;
+import jeju.oneroom.message.entity.Message;
+import org.mapstruct.*;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface MessageMapper {
+
+    Message messagePostDtoToMessage(MessageDto.Post messagePostDto);
+
+    @Mapping(target = "messageRoomId", source = "messageRoom.messageRoomId")
+    @Mapping(target = "senderId", source = "sender.id")
+    @Mapping(target = "senderName", source = "sender.nickname")
+    @Mapping(target = "receiverId", source = "receiver.id")
+    @Mapping(target = "receiverName", source = "receiver.nickname")
+    MessageDto.Response messageToMessageResponseDto(Message message);
+}

--- a/server/src/main/java/jeju/oneroom/message/redis/RedisPublisher.java
+++ b/server/src/main/java/jeju/oneroom/message/redis/RedisPublisher.java
@@ -1,0 +1,26 @@
+package jeju.oneroom.message.redis;
+
+import jeju.oneroom.message.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisPublisher {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void publish(ChannelTopic topic, MessageDto.Response message) {
+        try {
+            redisTemplate.convertAndSend(topic.getTopic(), message);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+
+        log.info("redis로 메시지 발행");
+    }
+}

--- a/server/src/main/java/jeju/oneroom/message/redis/RedisSubscriber.java
+++ b/server/src/main/java/jeju/oneroom/message/redis/RedisSubscriber.java
@@ -1,0 +1,39 @@
+package jeju.oneroom.message.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jeju.oneroom.message.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String publishMessage = String.valueOf(redisTemplate
+                    .getStringSerializer()
+                    .deserialize(message.getBody())
+            );
+
+            MessageDto.Response responseDto = objectMapper.readValue(publishMessage, MessageDto.Response.class);
+            log.info("message = {}", responseDto);
+
+            messagingTemplate.convertAndSend("/sub/room/" + responseDto.getMessageRoomId(), responseDto);
+            log.info("redis에서 메시지 받아옴");
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/server/src/main/java/jeju/oneroom/message/repository/MessageRepository.java
+++ b/server/src/main/java/jeju/oneroom/message/repository/MessageRepository.java
@@ -1,0 +1,7 @@
+package jeju.oneroom.message.repository;
+
+import jeju.oneroom.message.entity.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/server/src/main/java/jeju/oneroom/message/service/MessageService.java
+++ b/server/src/main/java/jeju/oneroom/message/service/MessageService.java
@@ -1,0 +1,43 @@
+package jeju.oneroom.message.service;
+
+import jeju.oneroom.message.dto.MessageDto;
+import jeju.oneroom.message.entity.Message;
+import jeju.oneroom.message.mapper.MessageMapper;
+import jeju.oneroom.message.redis.RedisPublisher;
+import jeju.oneroom.message.repository.MessageRepository;
+import jeju.oneroom.messageroom.entity.MessageRoom;
+import jeju.oneroom.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MessageService {
+
+    private final MessageMapper messageMapper;
+    private final MessageRepository messageRepository;
+    private final RedisPublisher redisPublisher;
+
+    public MessageDto.Response createMessage(MessageDto.Post postDto, MessageRoom messageRoom, User sender, User receiver) {
+        Message message = messageMapper.messagePostDtoToMessage(postDto);
+        message.setProperties(messageRoom, sender, receiver);
+        messageRoom.setMessageRoom(message);
+
+        MessageDto.Response responseDto = messageMapper.messageToMessageResponseDto(messageRepository.save(message));
+
+        publishMessageToRedis(messageRoom, responseDto);
+
+        return responseDto;
+    }
+
+    private void publishMessageToRedis(MessageRoom messageRoom, MessageDto.Response messageDto) {
+        String topic = "messageRoom" + messageRoom.getMessageRoomId();
+
+        redisPublisher.publish(ChannelTopic.of(topic), messageDto);
+    }
+}

--- a/server/src/main/java/jeju/oneroom/messageroom/controller/MessageRoomController.java
+++ b/server/src/main/java/jeju/oneroom/messageroom/controller/MessageRoomController.java
@@ -1,0 +1,73 @@
+package jeju.oneroom.messageroom.controller;
+
+import jeju.oneroom.common.dto.MultiResponseDto;
+import jeju.oneroom.messageroom.dto.MessageRoomDto;
+import jeju.oneroom.messageroom.service.MessageRoomService;
+import jeju.oneroom.user.entity.User;
+import jeju.oneroom.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+
+@Slf4j
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/messagerooms")
+public class MessageRoomController {
+
+    private final UserService userService;
+    private final MessageRoomService messageRoomService;
+
+    // 채팅방 생성
+    @PostMapping
+    public ResponseEntity<MessageRoomDto.SimpleResponse> postMessageRoom(@Valid @RequestBody MessageRoomDto.Post postDto) {
+        User sender = userService.verifyExistsUser(postDto.getSenderId());  // email
+        User receiver = userService.verifyExistsUser(postDto.getReceiverId());
+
+        MessageRoomDto.SimpleResponse response = messageRoomService.createMessageRoom(postDto, sender, receiver);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    // 특정 유저의 모든 채팅방 조회
+    @GetMapping("/{user-id}")
+    public ResponseEntity<MultiResponseDto<MessageRoomDto.SimpleResponse>> getMessageRooms(@PathVariable("user-id") @Positive Long userId,
+                                                                                           @RequestParam @Positive int page,
+                                                                                           @RequestParam @Positive int size) {
+        userService.verifyExistsUser(userId);
+
+        Page<MessageRoomDto.SimpleResponse> responses = messageRoomService.findMessageRoomsByUserId(userId, page, size);    //email
+
+        return new ResponseEntity<>(new MultiResponseDto<>(responses), HttpStatus.OK);
+    }
+
+    // 특정 유저의 특정 채팅방 조회
+    @GetMapping("/{user-id}/{messageroom-id}")
+    public ResponseEntity<MessageRoomDto.Response> getMessages(@PathVariable("user-id") @Positive Long userId,
+                                                               @PathVariable("messageroom-id") @Positive Long messageRoomId) {
+        User user = userService.verifyExistsUser(userId);   // email
+
+        MessageRoomDto.Response response = messageRoomService.findMessages(user, messageRoomId);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // 특정 채팅방 삭제
+    @DeleteMapping("/{user-id}/{messageroom-id}")
+    public ResponseEntity<HttpStatus> deleteMessageRoom(@PathVariable("user-id") @Positive Long userId,
+                                                        @PathVariable("messageroom-id") @Positive Long messageRoomId) {
+        User user = userService.verifyExistsUser(userId);   // email
+
+        messageRoomService.deleteMessageRoom(user, messageRoomId);
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/server/src/main/java/jeju/oneroom/messageroom/dto/MessageRoomDto.java
+++ b/server/src/main/java/jeju/oneroom/messageroom/dto/MessageRoomDto.java
@@ -1,0 +1,52 @@
+package jeju.oneroom.messageroom.dto;
+
+import jeju.oneroom.message.dto.MessageDto;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MessageRoomDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Post {
+
+        @NotNull
+        private Long senderId;
+
+        @NotNull
+        private Long receiverId;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+
+        private Long messageRoomId;
+        private Long senderId;
+        private String senderName;
+        private Long receiverId;
+        private String receiverName;
+        private List<MessageDto.Response> messages;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SimpleResponse {
+
+        private Long messageRoomId;
+        private String messageRoomStatus;
+        private String lastMessage;
+        private Long lastSenderId;
+        private LocalDateTime createdAt;
+    }
+}

--- a/server/src/main/java/jeju/oneroom/messageroom/entity/MessageRoom.java
+++ b/server/src/main/java/jeju/oneroom/messageroom/entity/MessageRoom.java
@@ -1,0 +1,64 @@
+package jeju.oneroom.messageroom.entity;
+
+import jeju.oneroom.common.entity.BaseEntity;
+import jeju.oneroom.message.entity.Message;
+import jeju.oneroom.user.entity.User;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long messageRoomId;
+
+    @Setter
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MessageRoomStatus messageRoomStatus;
+
+    @Column(nullable = true)
+    private String lastMessage;
+
+    @Column(nullable = true)
+    private Long lastSenderId;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = true)
+    private User sender;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = true)
+    private User receiver;
+
+    @OrderBy("messageId")
+    @OneToMany(mappedBy = "messageRoom", cascade = CascadeType.ALL)
+    private Set<Message> messages = new LinkedHashSet<>();
+
+    @Builder
+    public MessageRoom(Long messageRoomId, User sender, User receiver) {
+        this.messageRoomId = messageRoomId;
+        this.sender = sender;
+        this.receiver = receiver;
+    }
+
+    public void setProperties(User sender, User receiver) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.messageRoomStatus = MessageRoomStatus.UNCHECK;
+    }
+
+    public void setMessageRoom(Message message) {
+        this.lastMessage = message.getContent();
+        this.lastSenderId = message.getSender().getId();
+        this.messageRoomStatus = MessageRoomStatus.UNCHECK;
+    }
+}

--- a/server/src/main/java/jeju/oneroom/messageroom/entity/MessageRoomStatus.java
+++ b/server/src/main/java/jeju/oneroom/messageroom/entity/MessageRoomStatus.java
@@ -1,0 +1,6 @@
+package jeju.oneroom.messageroom.entity;
+
+public enum MessageRoomStatus {
+    CHECK,
+    UNCHECK
+}

--- a/server/src/main/java/jeju/oneroom/messageroom/mapper/MessageRoomMapper.java
+++ b/server/src/main/java/jeju/oneroom/messageroom/mapper/MessageRoomMapper.java
@@ -1,0 +1,19 @@
+package jeju.oneroom.messageroom.mapper;
+
+import jeju.oneroom.message.mapper.MessageMapper;
+import jeju.oneroom.messageroom.dto.MessageRoomDto;
+import jeju.oneroom.messageroom.entity.MessageRoom;
+import org.mapstruct.*;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, uses = MessageMapper.class)
+public interface MessageRoomMapper {
+    MessageRoom messageRoomPostDtoToMessageRoom(MessageRoomDto.Post postDto);
+
+    @Mapping(target = "senderId", source = "sender.id")
+    @Mapping(target = "senderName", source = "sender.nickname")
+    @Mapping(target = "receiverId", source = "receiver.id")
+    @Mapping(target = "receiverName", source = "receiver.nickname")
+    MessageRoomDto.Response messageRoomToMessageRoomResponseDto(MessageRoom messageRoom);
+
+    MessageRoomDto.SimpleResponse messageRoomToMessageRoomSimpleResponseDto(MessageRoom messageRoom);
+}

--- a/server/src/main/java/jeju/oneroom/messageroom/repository/MessageRoomRepository.java
+++ b/server/src/main/java/jeju/oneroom/messageroom/repository/MessageRoomRepository.java
@@ -1,0 +1,18 @@
+package jeju.oneroom.messageroom.repository;
+
+import jeju.oneroom.messageroom.entity.MessageRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MessageRoomRepository extends JpaRepository<MessageRoom, Long> {
+
+    @Query("SELECT mr FROM MessageRoom mr WHERE (mr.sender.id = :senderId AND mr.receiver.id = :receiverId) " +
+            "OR (mr.sender.id = :receiverId AND mr.receiver.id = :senderId)")
+    MessageRoom findMessageRoom(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
+
+    @Query("SELECT mr FROM MessageRoom mr WHERE mr.sender.id = :userId OR mr.receiver.id = :userId")
+    Page<MessageRoom> findMessageRoomsBySenderIdOrReceiverId(@Param("userId") Long userId, Pageable pageable);
+}

--- a/server/src/main/java/jeju/oneroom/messageroom/service/MessageRoomService.java
+++ b/server/src/main/java/jeju/oneroom/messageroom/service/MessageRoomService.java
@@ -1,0 +1,116 @@
+package jeju.oneroom.messageroom.service;
+
+import jeju.oneroom.message.entity.Message;
+import jeju.oneroom.message.redis.RedisSubscriber;
+import jeju.oneroom.message.repository.MessageRepository;
+import jeju.oneroom.messageroom.dto.MessageRoomDto;
+import jeju.oneroom.messageroom.entity.MessageRoom;
+import jeju.oneroom.messageroom.entity.MessageRoomStatus;
+import jeju.oneroom.messageroom.mapper.MessageRoomMapper;
+import jeju.oneroom.messageroom.repository.MessageRoomRepository;
+import jeju.oneroom.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MessageRoomService {
+
+    private final MessageRoomMapper messageRoomMapper;
+    private final MessageRoomRepository messageRoomRepository;
+    private final Map<String, ChannelTopic> topics;
+    private final RedisMessageListenerContainer redisMessageListener;
+    private final RedisSubscriber redisSubscriber;
+    private final MessageRepository messageRepository;
+
+    @Transactional
+    public MessageRoomDto.SimpleResponse createMessageRoom(MessageRoomDto.Post postDto, User sender, User receiver) {
+        if (messageRoomRepository.findMessageRoom(sender.getId(), receiver.getId()) != null) {
+            throw new RuntimeException("CHATROOM_ALREADY_EXISTS");
+        }
+
+        MessageRoom messageRoom = messageRoomMapper.messageRoomPostDtoToMessageRoom(postDto);
+        messageRoom.setProperties(sender, receiver);
+
+        MessageRoom savedMessageRoom = messageRoomRepository.save(messageRoom);
+
+        sendTopic(savedMessageRoom.getMessageRoomId());
+
+        return messageRoomMapper.messageRoomToMessageRoomSimpleResponseDto(savedMessageRoom);
+    }
+
+    public Page<MessageRoomDto.SimpleResponse> findMessageRoomsByUserId(Long userId, int page, int size) {
+        return messageRoomRepository.findMessageRoomsBySenderIdOrReceiverId(userId, PageRequest.of(page - 1, size))
+                .map(messageRoomMapper::messageRoomToMessageRoomSimpleResponseDto);
+    }
+
+    public MessageRoomDto.Response findMessages(User user, Long messageRoomId) {
+        MessageRoom messageRoom = findVerifiedMessageRoom(messageRoomId);
+        List<Message> messages = new ArrayList<>(messageRoom.getMessages());
+
+        if (!messages.isEmpty()) {
+            Message message = messages.get(messages.size() - 1);
+
+            if (user == message.getReceiver()) {
+                messageRoom.setMessageRoomStatus(MessageRoomStatus.CHECK);
+            }
+        }
+
+        MessageRoom savedMessageRoom = messageRoomRepository.save(messageRoom);
+
+        sendTopic(savedMessageRoom.getMessageRoomId());
+
+        return messageRoomMapper.messageRoomToMessageRoomResponseDto(savedMessageRoom);
+    }
+
+    @Transactional
+    public void deleteMessageRoom(User user, Long messageRoomId) {
+        MessageRoom messageRoom = findVerifiedMessageRoom(messageRoomId);
+        User sender = messageRoom.getSender();
+        User receiver = messageRoom.getReceiver();
+
+        if (user == sender) messageRoom.setSender(null);
+        if (user == receiver) messageRoom.setReceiver(null);
+
+        if (messageRoom.getSender() == null && messageRoom.getReceiver() == null) {
+            messageRepository.deleteAllById(messageRoom.getMessages()
+                    .stream()
+                    .map(Message::getMessageId)
+                    .collect(Collectors.toList()));
+
+            messageRoomRepository.deleteById(messageRoomId);
+        }
+    }
+
+    public MessageRoom findVerifiedMessageRoom(Long messageRoomId) {
+        return messageRoomRepository.findById(messageRoomId)
+                .orElseThrow(() -> new RuntimeException("MESSAGEROOM_NOT_FOUND"));
+    }
+
+    private void sendTopic(Long messageRoomId) {
+        String roomId = "messageRoom" + messageRoomId;
+        log.info("topics = {}", topics);
+
+        if (!topics.containsKey(roomId)) {
+            ChannelTopic topic = new ChannelTopic(roomId);
+            log.info("메시지 토픽 생성");
+
+            redisMessageListener.addMessageListener(redisSubscriber, topic);
+            topics.put(roomId, topic);
+
+            log.info("메시지 토픽 전송");
+            log.info("topics = {}", topics);
+        }
+    }
+}


### PR DESCRIPTION
## 개요
- [#111]

## 변경사항
- Stomp + Redis pub/sub으로 기능 구현
- WebSocket, Redis 라이브러리 추가
- Stomp 설정 및 Redis Pub/Sub 로직 구현
- MessageRoom, Message 도메인 로직 구현

## 추후 변경해야할 사항
- Redis host 환경 변수 변경 - yml
- Stomp 접근 허용 경로 추가 - WebSocketConfig
- MessageRoom, Message 도메인 로직 수정 필요할 수 있음 - 유저의 id -> email를 통한 처리로